### PR TITLE
Do not try and get lyrics if TvTunes is running

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.cu.lrclyrics" name="CU LRC Lyrics" version="3.1.0" provider-name="Taxigps|ronie">
+<addon id="script.cu.lrclyrics" name="CU LRC Lyrics" version="3.1.1" provider-name="Taxigps|ronie">
 	<requires>
 		<import addon="xbmc.python" version="2.19.0"/>
 		<import addon="script.module.chardet" version="2.1.2"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.1.1
+- Do not try and get lyrics if TvTunes is running
+
 v3.1.0
 - add support for mp4 files
 

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -47,7 +47,8 @@ class MAIN():
                 log('searching for manually defined lyrics')
                 self.get_manual_lyrics()
             # check if we are on the music visualization screen
-            elif xbmc.getCondVisibility("Window.IsVisible(12006)"):
+            # do not try and get lyrics if TvTunes is running as it will just be a theme that is about to stop
+            elif xbmc.getCondVisibility("Window.IsVisible(12006)") and xbmcgui.Window(10025).getProperty("TvTunesIsRunning") in [None, ""]:
                 if not self.triggered:
                     self.triggered = True
                     # notify user the script is running


### PR DESCRIPTION
I have seen the case where there is an attempt to get lyrics when TvTunes has triggered the playing of the track.  This can happen if you exit out of a TV Show quickly and end up going back past the Home screen.

This seems a bit overkill - and the user starts getting Lyric popups that they didn't expect.

This pull request will check to ensure that the track being played hasn't been started by TvTunes.

Thanks

Rob
