### PR TITLE
Clean up the Monitor and Player classes on exit

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.cu.lrclyrics" name="CU LRC Lyrics" version="3.1.1" provider-name="Taxigps|ronie">
+<addon id="script.cu.lrclyrics" name="CU LRC Lyrics" version="3.1.2" provider-name="Taxigps|ronie">
 	<requires>
 		<import addon="xbmc.python" version="2.19.0"/>
 		<import addon="script.module.chardet" version="2.1.2"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.1.2
+- Clean up the Monitor and Player classes on exit
+
 v3.1.1
 - Do not try and get lyrics if TvTunes is running
 

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -23,12 +23,18 @@ class MAIN():
         if ( __addon__.getSetting( "save_lyrics_path" ) == "" ):
             __addon__.setSetting(id="save_lyrics_path", value=os.path.join( __profile__.encode("utf-8"), "lyrics" ))
         self.main_loop()
+        self.cleanup_main()
 
     def setup_main(self):
         self.fetchedLyrics = []
         self.current_lyrics = Lyrics()
         self.MyPlayer = MyPlayer(function=self.myPlayerChanged)
         self.Monitor = MyMonitor(function = self.update_settings)
+
+    def cleanup_main(self):
+        # Clean up the monitor and Player classes on exit
+        del self.MyPlayer
+        del self.Monitor
 
     def get_scraper_list(self):
         self.scrapers = []


### PR DESCRIPTION
Hi Ronie,

I have been noticing the following error in my Kodi (Test System) log:

```
08:04:05 T:17960 WARNING: CPythonInvoker(0, C:\XBMC\Kodi-14-Helix\portable_data\addons
\script.cu.lrclyrics\default.py): the python script "C:\XBMC\Kodi-14-Helix\portable_data
\addons\script.cu.lrclyrics\default.py" has left several classes in memory that we couldn't 
clean up. The classes include: class PythonBindings::XBMCAddon_xbmc_Monitor_Director,
class PythonBindings::XBMCAddon_xbmc_Player_Director
```

On my system (Windows) I occassionally get a crash on exit (Not a big issue as it is exiting).  I really don't know if this causes the crash (It's hard to tell what is).  This pull request stops the log error appearing, and since the change I have not had a crash (But only tested it a handful of times - so not conclusive proof!).

Either way, I though it may be a good change to have?

Thanks
Rob